### PR TITLE
As discussed with maurits, we implement this into dexterity.membrane

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 0.2 - Unreleased
 ----------------
 
+- Keep constistent with plone's email login #12187, so don't lowercase email
+  addresses.
+  [saily]
+
 - Add basic membrane group behavior
   [saily]
 

--- a/dexterity/membrane/behavior/membraneuser.py
+++ b/dexterity/membrane/behavior/membraneuser.py
@@ -96,7 +96,7 @@ class MembraneUser(object):
 
     def getUserName(self):
         if self._use_email_as_username():
-            return self.context.email.lower()
+            return self.context.email
         return self.context.username
 
     def _use_email_as_username(self):
@@ -131,7 +131,7 @@ class MyUserAuthentication(grok.Adapter):
         """Returns True is password is authenticated, False if not.
         """
         user = IMembraneUserObject(self.context)
-        if credentials.get('login').lower() != user.getUserName().lower():
+        if credentials.get('login') != user.getUserName():
             # Should never happen, as the code should then never end
             # up here, but better safe than sorry.
             return False

--- a/dexterity/membrane/membrane_helpers.py
+++ b/dexterity/membrane/membrane_helpers.py
@@ -25,8 +25,7 @@ def get_brains_for_email(context, email, request=None):
         return []
     if email == '' or '@' not in email:
         return []
-    # We only store lowercase emails.
-    email = email.lower()
+
     user_catalog = getToolByName(context, TOOLNAME, None)
     if user_catalog is None:
         logger.warn("membrane_tool not found.")

--- a/dexterity/membrane/tests/test_member.py
+++ b/dexterity/membrane/tests/test_member.py
@@ -79,19 +79,26 @@ class TestMember(TestCase):
         member.confirm_password = 'secret'
         membrane = getToolByName(self.portal, 'membrane_tool')
         membrane.reindexObject(member)
+
         # Uppercase:
         user_id = get_user_id_for_email(self.portal, 'JOE@EXAMPLE.ORG')
-        self.assertTrue(user_id)
-        # Mixed case:
-        user_id = get_user_id_for_email(self.portal, 'JOE@example.org')
-        self.assertTrue(user_id)
+        self.assertFalse(user_id)
+
         # Lowercase:
         user_id = get_user_id_for_email(self.portal, 'joe@example.org')
+        self.assertFalse(user_id)
+
+        # Mixed case:
+        user_id = get_user_id_for_email(self.portal, 'joe@EXAMPLE.org')
+        self.assertFalse(user_id)
+
+        # Mixed case:
+        user_id = get_user_id_for_email(self.portal, 'JOE@example.org')
         self.assertTrue(user_id)
 
         # Real authentication is pickier on the case unfortunately.
         auth = self.portal.acl_users.membrane_users.authenticateCredentials
-        credentials = {'login': 'joe@example.org', 'password': 'secret'}
+        credentials = {'login': 'JOE@example.org', 'password': 'secret'}
         # First the member needs to be enabled before authentication
         # can succeed.
         self.assertEqual(auth(credentials), None)
@@ -99,7 +106,7 @@ class TestMember(TestCase):
         self.setRoles(['Reviewer'])
         wf_tool.doActionFor(member, 'approve')
         self.setRoles([])
-        self.assertEqual(auth(credentials), (user_id, 'joe@example.org'))
+        self.assertEqual(auth(credentials), (user_id, 'JOE@example.org'))
 
         # It would be nice if we could get the next test to pass by
         # setting self.portal.membrane_tool.case_sensitive_auth to


### PR DESCRIPTION
to be consistent with plone's default behaviour.
