### PR TITLE
Added IProvidePasswords to membranepassword

### DIFF
--- a/dexterity/membrane/behavior/membranepassword.py
+++ b/dexterity/membrane/behavior/membranepassword.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from password import IProvidePasswordsSchema as BBBIProvidePasswordsSchema
+from password import IProvidePasswords as BBBIProvidePasswords
 
 
 class IProvidePasswordsSchema(BBBIProvidePasswordsSchema):
+    """ BBB class for zc.relations stuff and other weirdness """
+
+class IProvidePasswords(BBBIProvidePasswords):
     """ BBB class for zc.relations stuff and other weirdness """


### PR DESCRIPTION
Because I haven't found a way to upgrade existing content to work on 1.1.1, I added  IProvidePasswords to the membranepassword.py. Ideally I should have create an upgrade script to fix the issues I'm experiencing (see issue #23) - anyone know where to start?