### PR TITLE
Support login by email even when not using UUID userids fixes #26

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable use_email_as_username without use_uuid_as_userid.
+  This fixes getUserId, which fixes the indexed user values,
+  which fixes enumerateUsers.
+  Fixes https://github.com/collective/dexterity.membrane/issues/26
+  [gyst]
 
 
 1.1.2 (2016-08-05)

--- a/dexterity/membrane/behavior/user.py
+++ b/dexterity/membrane/behavior/user.py
@@ -73,9 +73,8 @@ class DxUserObject(object):
     def getUserId(self):
         if self._use_uuid_as_userid():
             return IUUID(self.context)
-        # issue #26: the username field is actually the userid
-        # avoid using getUserName since that might return the email address
-        return self.context.username
+        # #26: do not assume username == userid
+        return self.context.getId()
 
     def getUserName(self):
         if self._use_email_as_username():

--- a/dexterity/membrane/behavior/user.py
+++ b/dexterity/membrane/behavior/user.py
@@ -73,7 +73,9 @@ class DxUserObject(object):
     def getUserId(self):
         if self._use_uuid_as_userid():
             return IUUID(self.context)
-        return self.getUserName()
+        # issue #26: the username field is actually the userid
+        # avoid using getUserName since that might return the email address
+        return self.context.username
 
     def getUserName(self):
         if self._use_email_as_username():

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     ],
     extras_require={
         'test': [
+            'plone.api',
             'plone.app.testing',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '1.1.3.dev0'
+version = '1.1.3.dev1'
 
 setup(
     name='dexterity.membrane',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '1.1.3.dev1'
+version = '1.1.3.dev2'
 
 setup(
     name='dexterity.membrane',


### PR DESCRIPTION
It took me a dozen hours to prove this one-line fix :-(.

Summary: when using email logins without UUID, as is required when working with LDAP, dexterity.membrane breaks. Users are not enumerated, because the enumeration queries on `exact_getUserId`, which relies on the indexed return value of `getUserId`, which returns the email address instead of the actual userid. To further complicate matters, the userid is stored in a field called ``username`` but the username (login name) in this scenario is actually the email address stored in the ``email`` field.