### PR TITLE
Depend on plone.api

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
+- Depend on plone.api
+  [ale-rt]
 - Fixed some docstring
   [ale-rt]
 - Biography: plone.app.textfield RichText field for Plone 5

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Products.CMFPlone>=4.3',
         'Products.membrane>=2.0.2',
         'bcrypt>=2.0',
+        'plone.api',
         'plone.app.dexterity',
         'plone.app.referenceablebehavior>=0.7.0',
         'plone.memoize',
@@ -48,7 +49,6 @@ setup(
     ],
     extras_require={
         'test': [
-            'plone.api',
             'plone.app.testing',
         ],
     },


### PR DESCRIPTION
After merging #36 I realized it made the package dependent from plone.api, but this package requires plone.api only for the [test] feature.
I think it is ok to use plone.api here.