### PR TITLE
Added view to default_methods on example member's FTI 

### DIFF
--- a/dexterity/membrane/profiles/example/types/dexterity.membrane.member.xml
+++ b/dexterity/membrane/profiles/example/types/dexterity.membrane.member.xml
@@ -44,6 +44,7 @@
   <property name="default_view">view</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
+    <element value="view" />
     <element value="base_view" />
   </property>
 


### PR DESCRIPTION
Added view to default_methods on example member's FTI because cloning content type failed in @@dexterity-types