### PR TITLE
Performance improvements: cache expensive bcrypt operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 3.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Performance improvements: cache expensive bcrypt operations
+  [ale-rt]
 
 
 3.0.0a1 (2020-02-19)

--- a/dexterity/membrane/behavior/password.py
+++ b/dexterity/membrane/behavior/password.py
@@ -163,6 +163,10 @@ class MembraneUserAuthentication(object):
     def __init__(self, context):
         self.context = context
 
+    @ram.cache(_forever_cache_key)
+    def _pw_validate(self, reference, password):
+        return AuthEncoding.pw_validate(reference, password)
+
     def verifyCredentials(self, credentials):
         """Returns True is password is authenticated, False if not.
         """
@@ -174,9 +178,8 @@ class MembraneUserAuthentication(object):
         password_provider = IProvidePasswordsSchema(self.context)
         if not password_provider:
             return False
-        return AuthEncoding.pw_validate(
-            password_provider.password,
-            credentials.get('password', '')
+        return self._pw_validate(
+            password_provider.password, credentials.get('password', '')
         )
 
     def authenticateCredentials(self, credentials):


### PR DESCRIPTION
This is a follow up to https://github.com/collective/dexterity.membrane/pull/33